### PR TITLE
remove duplicate key in menus config

### DIFF
--- a/config/_default/menus.toml
+++ b/config/_default/menus.toml
@@ -29,6 +29,5 @@
 # [[main]]
 # name = "github"
 # pre = "github"
-# name = ""
 # url = "https://github.com/mnjm/kayal"
 # weight = 4


### PR DESCRIPTION
Removed the duplicated key `name` in `config/_default/menus.toml`, which was causing errors while building the site.