### PR TITLE
Dev new blockquote theme

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -161,14 +161,70 @@ table td{
   border-top: 1px solid var(--secondary-color-dark);
 }
 
+/* Blockquote */
 blockquote {
-  border-left: 4px solid var(--tertiary-color);
-  margin: 0;
-  padding-left: 2rem;
   background: var(--secondary-color-dark);
   box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.5);
+  border-left: 4px solid var(--tertiary-color);
   border-radius: 0 var(--radius) var(--radius) 0;
+  display: grid;
+  grid-template-columns: 30px auto;
+  margin: 0;
+  padding-left: 2rem;
 }
+
+blockquote::before {
+  background-repeat: no-repeat;
+  content: "";
+  width: 1em;
+  height: 1em;
+  grid-column: 1;
+}
+
+blockquote > * {
+  grid-column: 2;
+}
+
+blockquote.info {
+  border-color: var(--blockquote-info);
+  background-color: var(--blockquote-info-bg);
+  color: var(--black);
+}
+blockquote.info::before {
+  /* rgb(100, 130, 180) */
+  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="rgb(100, 130, 180)" d="M256 0C114.6 0 0 114.6 0 256s114.6 256 256 256s256-114.6 256-256S397.4 0 256 0zM256 128c17.67 0 32 14.33 32 32c0 17.67-14.33 32-32 32S224 177.7 224 160C224 142.3 238.3 128 256 128zM296 384h-80C202.8 384 192 373.3 192 360s10.75-24 24-24h16v-64H224c-13.25 0-24-10.75-24-24S210.8 224 224 224h32c13.25 0 24 10.75 24 24v88h16c13.25 0 24 10.75 24 24S309.3 384 296 384z"/></svg>');
+}
+
+blockquote.tip {
+  border-color: var(--blockquote-tip);
+  background-color: var(--blockquote-tip-bg);
+  color: var(--black);
+}
+blockquote.tip::before {
+  /* rgb(120, 170, 160) */
+  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512"><!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.--><path fill="rgb(120, 170, 160)" d="M272 384c9.6-31.9 29.5-59.1 49.2-86.2c0 0 0 0 0 0c5.2-7.1 10.4-14.2 15.4-21.4c19.8-28.5 31.4-63 31.4-100.3C368 78.8 289.2 0 192 0S16 78.8 16 176c0 37.3 11.6 71.9 31.4 100.3c5 7.2 10.2 14.3 15.4 21.4c0 0 0 0 0 0c19.8 27.1 39.7 54.4 49.2 86.2l160 0zM192 512c44.2 0 80-35.8 80-80l0-16-160 0 0 16c0 44.2 35.8 80 80 80zM112 176c0 8.8-7.2 16-16 16s-16-7.2-16-16c0-61.9 50.1-112 112-112c8.8 0 16 7.2 16 16s-7.2 16-16 16c-44.2 0-80 35.8-80 80z"/></svg>');
+}
+
+blockquote.warning {
+  border-color: var(--blockquote-warning);
+  background-color: var(--blockquote-warning-bg);
+  color: var(--black);
+}
+blockquote.warning::before {
+  /* rgb(200, 150, 50) */
+  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.--><path fill="rgb(200, 150, 50)" d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7 .2 40.1S486.3 480 472 480L40 480c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8 .2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24l0 112c0 13.3 10.7 24 24 24s24-10.7 24-24l0-112c0-13.3-10.7-24-24-24zm32 224a32 32 0 1 0 -64 0 32 32 0 1 0 64 0z"/></svg>');
+}
+
+blockquote.danger {
+  border-color: var(--blockquote-danger);
+  background-color: var(--blockquote-danger-bg);
+  color: var(--black);
+}
+blockquote.danger::before {
+  /* rgb(180, 100, 100) */
+  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.--><path fill="rgb(180, 100, 100)" d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM175 175c9.4-9.4 24.6-9.4 33.9 0l47 47 47-47c9.4-9.4 24.6-9.4 33.9 0s9.4 24.6 0 33.9l-47 47 47 47c9.4 9.4 9.4 24.6 0 33.9s-24.6 9.4-33.9 0l-47-47-47 47c-9.4 9.4-24.6 9.4-33.9 0s-9.4-24.6 0-33.9l47-47-47-47c-9.4-9.4-9.4-24.6 0-33.9z"/></svg>');
+}
+
 
 details {
   border-left: 4px solid var(--tertiary-color);

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -998,3 +998,18 @@ pre code::-webkit-scrollbar-thumb:hover {
   overflow: hidden;
   text-overflow: ellipsis;
 }
+
+/* Clicking outside the search area will close the search. */
+#search-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 1;
+}
+
+#search-results,
+.panel {
+  z-index: 2;
+}

--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -13,6 +13,16 @@
   --code-scroll-thumb: #525252;
   --scrollbar-track: #EFEFE6;
   --scrollbar-thumb: #B7B78F;
+
+  --blockquote-info: rgb(100, 130, 180);
+  --blockquote-tip: rgb(120, 170, 160);
+  --blockquote-warning: rgb(200, 150, 50);
+  --blockquote-danger: rgb(180, 100, 100);
+
+  --blockquote-info-bg: rgba(216, 232, 255, 0.7);
+  --blockquote-tip-bg: rgba(226, 245, 236, 0.7);
+  --blockquote-warning-bg: rgba(255, 248, 216, 0.7);
+  --blockquote-danger-bg: rgba(255, 224, 224, 0.7);
 }
 
 .dark {

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -98,7 +98,10 @@ window.addEventListener("DOMContentLoaded", (event) => {
   searchTxt = document.getElementById("search-query");
 
   seachOpnBtn.addEventListener("click", openSearch);
-  closeBtn.addEventListener("click", closeSearch);
+  closeBtn.addEventListener("click", (event) => {
+    event.preventDefault();
+    closeSearch();
+  });
 
   searchTxt.onkeyup = function (event) {
     executeQuery(this.value);

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -25,7 +25,7 @@ function fetchJSON(path, callback) {
 
 function buildIndex() {
   var baseURL = searchCntr.getAttribute("data-url");
-  baseURL = baseURL.replace(/\/?$/, '/');
+  baseURL = baseURL.replace(/\/?$/, "/");
   fetchJSON(baseURL + "index.json", function (data) {
     var options = {
       shouldSort: true,
@@ -67,12 +67,13 @@ function closeSearch() {
 function executeQuery(query) {
   let results = fuse.search(query);
   let resultsHtml = "";
-  if (results.length > 1) {
+  if (results.length >= 1) {
     results.forEach(function (value, key) {
       var meta = value.item.section + " | ";
-      meta = meta + value.item.date ? value.item.date + " | ": "";
-      meta = meta + `<span class="srch-link">${value.item.permalink}</span>`
-      resultsHtml = resultsHtml +
+      meta = meta + value.item.date ? value.item.date + " | " : "";
+      meta = meta + `<span class="srch-link">${value.item.permalink}</span>`;
+      resultsHtml =
+        resultsHtml +
         `<li><a href="${value.item.permalink}">
           <p class="srch-title">${value.item.title}</p>
           <p class="srch-meta">${meta}</p>
@@ -104,12 +105,12 @@ window.addEventListener("DOMContentLoaded", (event) => {
   };
 
   searchTxt.onkeydown = function (event) {
-    if ((event.key == "Enter") && (!isResEmpty)) {
+    if (event.key == "Enter" && !isResEmpty) {
       // Enter to focus on the first search result
       resultCntr.firstChild.firstElementChild.focus();
       event.preventDefault();
     }
-  }
+  };
 });
 
 document.addEventListener("keydown", function (event) {
@@ -122,19 +123,23 @@ document.addEventListener("keydown", function (event) {
     if (event.key == "Escape") {
       event.preventDefault();
       closeSearch();
-    } else if ((event.key == "ArrowDown") && (!isResEmpty)) {
+    } else if (event.key == "ArrowDown" && !isResEmpty) {
       if (document.activeElement == searchTxt) {
         resultCntr.firstChild.firstElementChild.focus();
-      } else if (document.activeElement == resultCntr.lastChild.firstElementChild) {
+      } else if (
+        document.activeElement == resultCntr.lastChild.firstElementChild
+      ) {
         searchTxt.focus();
       } else {
         document.activeElement.parentElement.nextSibling.firstElementChild.focus();
       }
       event.preventDefault();
-    } else if ((event.key == "ArrowUp") && (!isResEmpty)) {
+    } else if (event.key == "ArrowUp" && !isResEmpty) {
       if (document.activeElement == searchTxt) {
         resultCntr.lastChild.firstElementChild.focus();
-      } else if (document.activeElement == resultCntr.firstChild.firstElementChild) {
+      } else if (
+        document.activeElement == resultCntr.firstChild.firstElementChild
+      ) {
         searchTxt.focus();
       } else {
         document.activeElement.parentElement.previousSibling.firstElementChild.focus();

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -151,3 +151,8 @@ document.addEventListener("keydown", function (event) {
     }
   }
 });
+
+// Clicking outside the search area will close the search.
+document.getElementById("search-overlay").addEventListener("click", () => {
+  closeSearch();
+});

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -22,5 +22,6 @@
       </main>
       {{ partial "footer.html" . }}
     </div>
+    {{ partialCached "head/js.html" . }}
   </body>
 </html>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -23,7 +23,6 @@
   <link rel="canonical" href="{{ .Permalink }}" />
 
   {{ partialCached "head/css.html" . }}
-  {{ partialCached "head/js.html" . }}
 
   {{/* Icons */}}
   {{ if templates.Exists "partials/favicons.html" }}

--- a/layouts/partials/search.html
+++ b/layouts/partials/search.html
@@ -26,5 +26,6 @@
       <!--  <p class="srch-smry">This article offers a sample of basic Markdown formatting that can be used in Kayal, also it shows how some basic HTML elements are decorated.\n</p>-->
       <!--</a></li>-->
     </ul>
+    <div id="search-overlay"></div>
   </div>
 </div>


### PR DESCRIPTION
You can add styles like this:

```md
> block
>
> quote
{class="info"}
```

The added classes are `info`, `tip`, `warning`, and `danger`.


...
I'm sorry, but it seems that the blockquote styles accidentally overlapped with the changes made to the search functionality. I apologize for that.

You only need to check the section under `/* Blockquote */` in *main.css* and the new variables added in *theme.css*.

This one -> feat: Add styles for the info, tip, warning, and danger classes to th…