### PR TITLE
bump patch number to match latest Hugo version

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -2,4 +2,4 @@
 [module.hugoVersion]
 extended = false
 min = "0.125.4"
-max = "0.147.5"
+max = "0.147.8"


### PR DESCRIPTION
I don't expect bumping a patch version would break anything, but I'm unsure the best path to test.