### PR TITLE
`htmlUnescape` post descriptions in RSS feeds

### DIFF
--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -39,7 +39,7 @@
       <pubDate>{{ .PublishDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
       {{- with site.Params.Author.email }}<author>{{ . }}{{ with site.Params.Author.name }} ({{ . }}){{ end }}</author>{{ end }}
       <guid>{{ .Permalink }}</guid>
-      <description>{{ with .Description | plainify }}{{ . }}{{ else }}{{ .Summary | plainify }}{{ end -}}</description>
+      <description>{{ with .Description | plainify | htmlUnescape }}{{ . }}{{ else }}{{ .Summary | plainify | htmlUnescape }}{{ end -}}</description>
       {{- if and site.Params.ShowFullTextinRSS .Content }}
       <content:encoded>{{ (printf "<![CDATA[%s]]>" .Content) | safeHTML }}</content:encoded>
       {{- end }}


### PR DESCRIPTION
Post summaries with `"` characters break RSS feeds on Hugo `0.132.0` and above:

![XML parse error](https://github.com/user-attachments/assets/23d26fe4-7e45-482a-b627-aaa60d7aa53f)

Because of that, I've [forked](https://github.com/Expurple/home.expurple.me/commit/7f57dbfb22dd83d15571272c0ad7253b8515dd1a) the RSS template for my website. The change fixes such RSS feeds on Hugo `0.132.0` and above. `0.131.0` still works too. I haven't tried the older Hugo versions.

You can verify this by:

1. Cloning my website at commits [ca85a27](https://github.com/Expurple/home.expurple.me/tree/ca85a27b4c32e578f67c5d1f28978c580e6fe006) (right before the change) and [7f57dbf](https://github.com/Expurple/home.expurple.me/tree/7f57dbfb22dd83d15571272c0ad7253b8515dd1a) (with the change included).
2. Running `hugo server` with Hugo `0.131.0` / `0.132.0`.
3. Opening `http://localhost:1313/posts/index.xml` in Firefox or Chromium.

I'm not sure why Hugo `0.132.0` changed HTML/XML escaping in the first place. The [release notes](https://github.com/gohugoio/hugo/releases/tag/v0.132.0) don't say anything about this. I have a hard time finding any relevant info. The closest issue I [found](https://github.com/gohugoio/hugo/issues?q=is%3Aissue%20rss%20escape) is https://github.com/gohugoio/hugo/issues/11615. It links to a theme that [uses](https://github.com/dataCobra/hugo-vitae/blob/main/layouts/_default/rss.xml#L52) `htmlUnescape`. That gave me an idea to use `htmlUnescape`.

In both cases, I don't fully understand the pipeline. But I've tested the `&` problem from that issue, and it doesn't reproduce with my template.