### PR TITLE
Reduce content max-width to 90ch

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -202,7 +202,7 @@ details[open] div {
 
 .content {
   margin: 0 auto;
-  max-width: 900px;
+  max-width: 90ch;
 }
 
 /* Header */


### PR DESCRIPTION
I recently [did](https://github.com/Expurple/home.expurple.me/commit/99e67956d1f1007410a7ad2796dcb4e198b8d4fe) this on my website. I find it much more readable, while still preserving your feel and not going into the "narrow" territory. Your current width is roughly 110 characters.

You can browse and compare my [live website](https://home.expurple.me/posts/why-use-structured-errors-in-rust-applications/) (90ch) to the [last archived version](https://web.archive.org/web/20250528100910/https://home.expurple.me/posts/why-use-structured-errors-in-rust-applications/) (900px).

Obviously, this is a subjective change, so feel free to make it more subtle or reject.