### PR TITLE
Taxonomy cards: remove `flex-basis`

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -753,7 +753,7 @@ pre:hover .copy-button {
 }
 
 .taxny-card {
-  flex: 1 0 200px;
+  flex: 1 0;
   margin: 10px;
   background-color: var(--secondary-color-dark);
   padding: 10px;


### PR DESCRIPTION
Right now, the tag cards are needlessly large:

![Screenshot before the change](https://github.com/user-attachments/assets/6d9dcba1-d702-451b-b12f-230c77a7a8ce)

I don't really understand CSS and flexboxes, but apparently `200px` sets the minimal card size in this case.

After the change:

![Screenshot after the change](https://github.com/user-attachments/assets/b75c59e5-6473-4bfc-9752-1e2d1e816434)
