### PR TITLE
Add horizontal spacing after regular icons

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -389,10 +389,6 @@ html:not(.dark) #sun {
   margin: 0.2em;
 }
 
-.icon {
-  position: relative;
-}
-
 .socials-icon svg {
   height:1.5em;
   width:1.5em;
@@ -690,6 +686,7 @@ pre:hover .copy-button {
   position: relative;
   display: inline-block;
   vertical-align: middle;
+  margin-right: 0.2em;
 }
 
 .icon svg {


### PR DESCRIPTION
Very similar to #66, but for regular icons. It looks better when an icon is not squashed right into the text that follows it.

Before:

![Screenshot before the change](https://github.com/user-attachments/assets/1f227922-735e-4cde-a0ce-ed49da582067)

After:

![Screenshot after the change](https://github.com/user-attachments/assets/8b943937-c569-4d6e-bbaa-4202f1834189)

I've also noticed and deleted a duplicated `.icon { position: relative; }`