### PR TITLE
Don't break inline code snippets on whitespace

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -97,6 +97,7 @@ code {
   word-break: break-word;
   word-wrap: break-word;
   overflow: break-word;
+  white-space: nowrap;
 }
 
 /*a code {*/


### PR DESCRIPTION
[Before](https://web.archive.org/web/20250701125143/https://home.expurple.me/posts/rust-solves-the-issues-with-exceptions/):

<img width="1026" height="68" alt="Screenshot before the change" src="https://github.com/user-attachments/assets/ae8e63ed-d6d7-4160-80f1-24456001724a" />

[After](https://home.expurple.me/posts/rust-solves-the-issues-with-exceptions/):

<img width="931" height="68" alt="Screenshot after the change" src="https://github.com/user-attachments/assets/f39aba2e-8bd3-4000-9905-7bded2156ec9" />