### PR TITLE
Remove the extra empty line from list items with paragraphs

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -74,6 +74,14 @@ ul li:before {
   margin-left: -1em;
 }
 
+/* https://github.com/mnjm/kayal/issues/62 */
+main ul li p:first-of-type {
+  display: inline;
+}
+main ul.lst li div.lst-a {
+  display: inline;
+}
+
 img {
   max-width: 100%;
   height: auto;


### PR DESCRIPTION
Fixes https://github.com/mnjm/kayal/issues/62.

The examples from that issue now render like this:

<img width="274" height="157" alt="Screenshot of list items with paragraphs" src="https://github.com/user-attachments/assets/e70a2fc5-db92-4544-8d47-5d56fcb6c18b" />

<img width="232" height="210" alt="Screenshot of the tags page" src="https://github.com/user-attachments/assets/d461b117-72a3-42b7-bc6a-1c90f93905e4" />

In each list item, the first paragraph now has an extra little whitespace node in front of it. But that's much better than a whole empty line. I'll track that in a new issue after you merge this