### PR TITLE
Consistent spacing between list items with paragraphs

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -74,6 +74,14 @@ ul li:before {
   margin-left: -1em;
 }
 
+/* https://github.com/mnjm/kayal/pull/76 */
+li:has(p) + li:has(p) {
+  margin-top: 7px;
+}
+li p:last-of-type {
+  margin-bottom: 0;
+}
+
 img {
   max-width: 100%;
   height: auto;


### PR DESCRIPTION
## PR dependency and ordering

This PR depends on #75 and shouldn't be merged without it. Without #75, paragraphs in lists are just unusable.

## The issue

On `main` with #75 applied, there are still some problems with paragraphs in lists:

1. There's too much space after an item containing several paragraphs.
2. There's no space between items containing a single paragraph. Those items visually blend together and are hard to read.

<img width="982" height="844" alt="Screenshot before" src="https://github.com/user-attachments/assets/e898f737-833f-45d7-97bb-f0e883e358ec" />

## The result of the fix

With #75 and this PR applied, the spacing between items with paragraphs is consistent:

<img width="982" height="858" alt="Screenshot after" src="https://github.com/user-attachments/assets/b8e3fae4-d2d7-47ca-9c69-4719bf3ab925" />

## Items without paragraphs

Note that list items without the `<p>` tag are still rendered as before, without extra space between them:

<img width="555" height="252" alt="Screenshot without paragraphs" src="https://github.com/user-attachments/assets/089312d0-4d01-49dd-b128-09fbb7322680" />

I liked and kept that.