### PR TITLE
Don't break tag cards across several lines

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -759,6 +759,7 @@ pre:hover .copy-button {
   background-color: var(--secondary-color-dark);
   padding: 10px;
   border-radius: var(--radius);
+  white-space: nowrap;
 }
 
 .comment {


### PR DESCRIPTION
Noticed this on mobile. Screenshots are from a zoomed-in desktop browser.

Before:

<img width="933" height="437" alt="Screenshot before" src="https://github.com/user-attachments/assets/4c1f6006-2889-4205-84d0-572e1f657530" />

After:

<img width="934" height="462" alt="Screenshot after" src="https://github.com/user-attachments/assets/08a73abc-f131-40fd-8b0d-d9df91ca1630" />
